### PR TITLE
tox: also test pypy, py35, py36, py37, py38, py39

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
 FROM n42org/tox
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libcurl4-openssl-dev libssl-dev build-essential libffi-dev
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libcurl4-openssl-dev libssl-dev build-essential libffi-dev python3-pip python3.8-dev python3.8-distutils python3.8-venv python3.9-dev

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, pypy, py31, py32, py33, py34
+envlist = pypy, py27, py31, py32, py33, py34, py35, py36, py37, py38, py39
 
 [testenv]
 deps =
@@ -13,3 +13,7 @@ deps =
     mock>=1.0.1
 commands =
     python -W always setup.py test {posargs}
+
+[testenv:pypy]
+install_command =
+    python -m pip install --no-binary=:all: {opts} {packages}


### PR DESCRIPTION
Dockerfile:
  - add Python 3.8 and 3.9 support (the rest is in the parent Dockerfile)

Tox:
 - handle pypy separately, use --no-binary=:all: